### PR TITLE
forceMultiPart TypeScript Definition for Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ When an options object is provided, the result types will be accurately inferred
 ```ts
 import formAutoContent from 'form-auto-content';
 
-const option = { payload: 'body', headers: 'head' } as const
+const option = {
+  payload: 'body',
+  headers: 'head',
+  forceMultiPart: true,
+} as const;
 
 const myCustomForm = formAutoContent({
   field1: 'value1',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,8 @@ import { Readable } from "stream";
 
 export type FormMethodOptions = {
   readonly payload?: string,
-  readonly headers?: string
+  readonly headers?: string,
+  readonly forceMultiPart?: boolean
 }
 
 type FormMethodDefaultOptions = {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -122,3 +122,28 @@ import { Readable } from "stream";
     // @ts-expect-error
   }, { foo: '' } as const);
 }
+
+{ // Test for forceMultiPart option set to true
+  const option = { forceMultiPart: true } as const;
+
+  const myForm = formAutoContent(
+    {
+      field1: 'value1',
+      field2: ['value2', 'value2.2'],
+    },
+    option
+  );
+
+  expectAssignable<{ payload: Readable; headers: Record<string, string> }>(myForm);
+}
+
+{ // Test for forceMultiPart option set to false
+  const option = { forceMultiPart: false } as const;
+
+  const myForm = formAutoContent({
+    field1: 'value1',
+    field2: ['value2', 'value2.2']
+  }, option);
+
+  expectAssignable<{ payload: Readable, headers: Record<string, string> }>(myForm);
+}


### PR DESCRIPTION
The forceMultiPart option is not available in TS, due to it missing from the definitions.

I added it to the FormMethodOptions definition, and I added two tests to help ensure the defs are working properly.

Let me know if you need any further changes to this PR and I will support it.

Fastify rocks!

Thank you.